### PR TITLE
Use configurable GHCR username for prod compose

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -34,7 +34,7 @@ services:
       retries: 10
 
   backend:
-    image: ghcr.io/ulietaight/apps-backend:latest
+    image: ghcr.io/${GHCR_USERNAME}/apps-backend:latest
     container_name: apps-backend
     restart: always
     networks:
@@ -55,7 +55,7 @@ services:
         condition: service_healthy
 
   frontend:
-    image: ghcr.io/ulietaight/apps-frontend:latest
+    image: ghcr.io/${GHCR_USERNAME}/apps-frontend:latest
     container_name: apps-frontend
     restart: always
     ports:

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Ensure GHCR_USERNAME is available for docker-compose substitutions
+export GHCR_USERNAME
+
 echo "🔐 Логинимся в GHCR..."
 echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
 


### PR DESCRIPTION
## Summary
- reference GHCR username env variable in prod docker-compose
- export GHCR_USERNAME in deploy script so compose can substitute it

## Testing
- `bash -n infra/scripts/deploy.sh`
- `GHCR_USERNAME=testuser docker-compose -f infra/docker-compose.prod.yml config` *(fails: command not found)*
- `npm test` *(backend: tests fail to compile modules)*
- `npm test` *(frontend: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a492ba3024833191d6801468e7824f