### PR TITLE
feat: add Riot ID login and match history

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { RedisModule } from './redis/redis.module';
 import { UserModule } from './user/user.module';
 import { TransactionModule } from './transaction/transaction.module';
+import { RiotModule } from './riot/riot.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { TransactionModule } from './transaction/transaction.module';
     UserModule,
     TransactionModule,
     RedisModule,
+    RiotModule,
     // другие модули позже (user, transaction и т.п.)
   ],
   controllers: [AppController],

--- a/backend/src/riot/riot.controller.ts
+++ b/backend/src/riot/riot.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { RiotService } from './riot.service';
+
+@Controller('riot')
+export class RiotController {
+  constructor(private readonly riotService: RiotService) {}
+
+  @Get('account/:gameName/:tagLine')
+  getAccount(@Param('gameName') gameName: string, @Param('tagLine') tagLine: string) {
+    return this.riotService.getAccount(gameName, tagLine);
+  }
+
+  @Get('matches/:gameName/:tagLine')
+  getMatches(@Param('gameName') gameName: string, @Param('tagLine') tagLine: string) {
+    return this.riotService.getLastMatches(gameName, tagLine);
+  }
+}

--- a/backend/src/riot/riot.module.ts
+++ b/backend/src/riot/riot.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RiotService } from './riot.service';
+import { RiotController } from './riot.controller';
+
+@Module({
+  providers: [RiotService],
+  controllers: [RiotController],
+})
+export class RiotModule {}

--- a/backend/src/riot/riot.service.ts
+++ b/backend/src/riot/riot.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+
+const RIOT_API_KEY = process.env.RIOT_API_KEY;
+const REGION = 'europe';
+
+@Injectable()
+export class RiotService {
+  private async fetchJson(url: string) {
+    const res = await fetch(url, {
+      headers: { 'X-Riot-Token': RIOT_API_KEY ?? '' },
+    });
+    if (!res.ok) {
+      throw new Error(`Riot API error: ${res.status}`);
+    }
+    return res.json();
+  }
+
+  async getAccount(gameName: string, tagLine: string) {
+    const url = `https://${REGION}.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${encodeURIComponent(gameName)}/${encodeURIComponent(tagLine)}`;
+    return this.fetchJson(url);
+  }
+
+  async getLastMatches(gameName: string, tagLine: string) {
+    const account = await this.getAccount(gameName, tagLine);
+    const { puuid } = account;
+    const idsUrl = `https://${REGION}.api.riotgames.com/lol/match/v5/matches/by-puuid/${puuid}/ids?start=0&count=25`;
+    const matchIds: string[] = await this.fetchJson(idsUrl);
+    const matchPromises = matchIds.map((id) =>
+      this.fetchJson(`https://${REGION}.api.riotgames.com/lol/match/v5/matches/${id}`),
+    );
+    return Promise.all(matchPromises);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,15 @@ import { useEffect, useState } from 'react';
 
 function App() {
   const [isOnline, setIsOnline] = useState<boolean | null>(null);
+  const [gameName, setGameName] = useState('');
+  const [tagLine, setTagLine] = useState('');
+  const [matches, setMatches] = useState<any[]>([]);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     const checkHealth = async () => {
       try {
-        const response = await fetch('/api/health')
+        const response = await fetch('/api/health');
         const data = await response.json();
         setIsOnline(data.status === 'ok');
       } catch (error) {
@@ -24,18 +28,64 @@ function App() {
     return isOnline ? 'Backend Online' : 'Backend Offline';
   };
 
-  const statusColor = isOnline === null ? 'bg-gray-400' : isOnline ? 'bg-green-500' : 'bg-red-500';
+  const statusColor =
+    isOnline === null ? 'bg-gray-400' : isOnline ? 'bg-green-500' : 'bg-red-500';
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMatches([]);
+    try {
+      const res = await fetch(
+        `/api/riot/matches/${encodeURIComponent(gameName)}/${encodeURIComponent(
+          tagLine,
+        )}`,
+      );
+      if (!res.ok) throw new Error('failed');
+      const data = await res.json();
+      setMatches(data);
+    } catch (err) {
+      setError('Не удалось загрузить матчи');
+    }
+  };
 
   return (
-    <div className="flex items-center gap-3">
-      <div
-        className={`w-4 h-4 rounded-full ${statusColor} animate-pulse`}
-        title={getStatusText()}
-      ></div>
-      <span className="text-sm text-gray-700">{getStatusText()}</span>
+    <div className="p-4 space-y-4">
+      <div className="flex items-center gap-3">
+        <div
+          className={`w-4 h-4 rounded-full ${statusColor} animate-pulse`}
+          title={getStatusText()}
+        ></div>
+        <span className="text-sm text-gray-700">{getStatusText()}</span>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          value={gameName}
+          onChange={(e) => setGameName(e.target.value)}
+          placeholder="Game Name"
+          className="border p-1"
+        />
+        <input
+          value={tagLine}
+          onChange={(e) => setTagLine(e.target.value)}
+          placeholder="Tag Line"
+          className="border p-1"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2">
+          Войти
+        </button>
+      </form>
+
+      {error && <div className="text-red-500">{error}</div>}
+
+      <ul className="list-disc pl-5">
+        {matches.map((m) => (
+          <li key={m?.metadata?.matchId}>{m?.metadata?.matchId}</li>
+        ))}
+      </ul>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
## Summary
- add Riot service, controller and module for Riot ID account lookup and last 25 matches
- wire Riot module into application
- implement frontend login form and match list

## Testing
- `npm test` (fails: Nest can't resolve dependencies in existing tests)
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a83c469df483319119d5f56d4ef942