### PR TITLE
feat: add Riot profile lookup queue

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "class-validator": "^0.14.1",
         "helmet": "^8.0.0",
         "ioredis": "^5.6.1",
+        "kafkajs": "^2.2.4",
         "pg": "^8.16.3",
         "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
@@ -8257,6 +8258,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kafkajs": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/keyv": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,7 +36,8 @@
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "kafkajs": "^2.2.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,8 @@ import { UserModule } from './user/user.module';
 import { TransactionModule } from './transaction/transaction.module';
 import { RiotModule } from './riot/riot.module';
 import { MetricsModule } from './metrics/metrics.module';
+import { KafkaModule } from './kafka/kafka.module';
+import { ProfilesModule } from './profiles/profiles.module';
 
 @Module({
   imports: [
@@ -18,6 +20,8 @@ import { MetricsModule } from './metrics/metrics.module';
     RedisModule,
     RiotModule,
     MetricsModule,
+    KafkaModule,
+    ProfilesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/kafka/kafka.module.ts
+++ b/backend/src/kafka/kafka.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { KafkaService } from './kafka.service';
+
+@Global()
+@Module({
+  providers: [KafkaService],
+  exports: [KafkaService],
+})
+export class KafkaModule {}

--- a/backend/src/kafka/kafka.service.ts
+++ b/backend/src/kafka/kafka.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Kafka, Producer, Consumer, EachMessagePayload } from 'kafkajs';
+
+@Injectable()
+export class KafkaService {
+  private readonly logger = new Logger(KafkaService.name);
+  private kafka: Kafka | null = null;
+  private producer: Producer | null = null;
+  private consumer: Consumer | null = null;
+
+  constructor() {
+    const brokers = process.env.KAFKA_BROKERS;
+    if (brokers) {
+      this.kafka = new Kafka({ brokers: brokers.split(',') });
+      this.producer = this.kafka.producer();
+      this.consumer = this.kafka.consumer({ groupId: process.env.KAFKA_GROUP_ID || 'app-group' });
+    } else {
+      this.logger.warn('KAFKA_BROKERS not set, Kafka disabled');
+    }
+  }
+
+  async emit(topic: string, message: any) {
+    if (!this.producer) return;
+    await this.producer.connect();
+    await this.producer.send({ topic, messages: [{ value: JSON.stringify(message) }] });
+  }
+
+  async consume(topic: string, handler: (payload: any) => Promise<void>) {
+    if (!this.consumer) return;
+    await this.consumer.connect();
+    await this.consumer.subscribe({ topic, fromBeginning: false });
+    await this.consumer.run({
+      eachMessage: async ({ message }: EachMessagePayload) => {
+        if (!message.value) return;
+        try {
+          const payload = JSON.parse(message.value.toString());
+          await handler(payload);
+        } catch (err) {
+          this.logger.error(`Failed to handle message from ${topic}`, err as Error);
+        }
+      },
+    });
+  }
+}

--- a/backend/src/profiles/dto/lookup.dto.ts
+++ b/backend/src/profiles/dto/lookup.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class LookupDto {
+  @IsString()
+  riotName: string;
+
+  @IsString()
+  tag: string;
+}

--- a/backend/src/profiles/profile.events.ts
+++ b/backend/src/profiles/profile.events.ts
@@ -1,0 +1,13 @@
+export interface ProfilesLookupRequested {
+  eventId: string;
+  riotName: string;
+  tag: string;
+  attempt: number;
+}
+
+export interface ProfilesLookupFailed {
+  eventId: string;
+  riotName: string;
+  tag: string;
+  reason: string;
+}

--- a/backend/src/profiles/profiles.controller.ts
+++ b/backend/src/profiles/profiles.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ProfilesService } from './profiles.service';
+import { LookupDto } from './dto/lookup.dto';
+
+@Controller('profiles')
+export class ProfilesController {
+  constructor(private readonly profilesService: ProfilesService) {}
+
+  @Post('lookup')
+  async lookup(@Body() dto: LookupDto) {
+    return this.profilesService.requestLookup(dto);
+  }
+}

--- a/backend/src/profiles/profiles.lookup.consumer.ts
+++ b/backend/src/profiles/profiles.lookup.consumer.ts
@@ -1,0 +1,54 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { KafkaService } from '../kafka/kafka.service';
+import { RiotService } from '../riot/riot.service';
+
+const MAX_ATTEMPTS = 3;
+
+@Injectable()
+export class ProfilesLookupConsumer implements OnModuleInit {
+  private readonly logger = new Logger(ProfilesLookupConsumer.name);
+
+  constructor(
+    private readonly kafka: KafkaService,
+    private readonly riot: RiotService,
+  ) {}
+
+  async onModuleInit() {
+    await this.kafka.consume(
+      'profiles.lookup.requested',
+      this.handle.bind(this),
+    );
+  }
+
+  private async handle(payload: any) {
+    const { eventId, riotName, tag, attempt = 0 } = payload;
+    try {
+      const account = await this.riot.getAccount(riotName, tag);
+      const matches = await this.riot.getLastMatches(riotName, tag);
+      const lastMatchId = matches[0]?.id;
+      await this.kafka.emit('ui.notify', {
+        eventId,
+        status: 'completed',
+        puuid: account.puuid,
+        lastMatchId,
+      });
+    } catch (error: any) {
+      this.logger.error(`Lookup failed for ${riotName}#${tag}: ${error?.message}`);
+      if (attempt + 1 < MAX_ATTEMPTS) {
+        await this.kafka.emit('profiles.lookup.requested', {
+          eventId,
+          riotName,
+          tag,
+          attempt: attempt + 1,
+        });
+      } else {
+        await this.kafka.emit('profiles.lookup.failed', {
+          eventId,
+          riotName,
+          tag,
+          reason: error?.message || 'unknown',
+        });
+      }
+    }
+  }
+}

--- a/backend/src/profiles/profiles.module.ts
+++ b/backend/src/profiles/profiles.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ProfilesController } from './profiles.controller';
+import { ProfilesService } from './profiles.service';
+import { ProfilesLookupConsumer } from './profiles.lookup.consumer';
+import { KafkaModule } from '../kafka/kafka.module';
+import { RiotModule } from '../riot/riot.module';
+
+@Module({
+  imports: [KafkaModule, RiotModule],
+  controllers: [ProfilesController],
+  providers: [ProfilesService, ProfilesLookupConsumer],
+})
+export class ProfilesModule {}

--- a/backend/src/profiles/profiles.service.ts
+++ b/backend/src/profiles/profiles.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { KafkaService } from '../kafka/kafka.service';
+import { LookupDto } from './dto/lookup.dto';
+
+@Injectable()
+export class ProfilesService {
+  constructor(private readonly kafka: KafkaService) {}
+
+  async requestLookup(dto: LookupDto) {
+    const eventId = randomUUID();
+    await this.kafka.emit('profiles.lookup.requested', {
+      eventId,
+      riotName: dto.riotName,
+      tag: dto.tag,
+      attempt: 0,
+    });
+    return { eventId };
+  }
+}

--- a/backend/src/transaction/transaction.controller.spec.ts
+++ b/backend/src/transaction/transaction.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TransactionController } from './transaction.controller';
+import { TransactionService } from './transaction.service';
 
 describe('TransactionController', () => {
   let controller: TransactionController;
@@ -7,6 +8,12 @@ describe('TransactionController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TransactionController],
+      providers: [
+        {
+          provide: TransactionService,
+          useValue: { transfer: jest.fn() },
+        },
+      ],
     }).compile();
 
     controller = module.get<TransactionController>(TransactionController);

--- a/backend/src/transaction/transaction.service.spec.ts
+++ b/backend/src/transaction/transaction.service.spec.ts
@@ -6,7 +6,11 @@ describe('TransactionService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TransactionService],
+      providers: [
+        TransactionService,
+        { provide: 'TransferStrategy', useValue: { transfer: jest.fn() } },
+        { provide: 'REDIS_CLIENT', useValue: { del: jest.fn() } },
+      ],
     }).compile();
 
     service = module.get<TransactionService>(TransactionService);

--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
+import { UserService } from './user.service';
 
 describe('UserController', () => {
   let controller: UserController;
@@ -7,6 +8,12 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
+      providers: [
+        {
+          provide: UserService,
+          useValue: { createUser: jest.fn(), getBalance: jest.fn() },
+        },
+      ],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('UserService', () => {
   let service: UserService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        { provide: 'REDIS_CLIENT', useValue: { get: jest.fn(), setex: jest.fn() } },
+        { provide: PrismaService, useValue: { user: { create: jest.fn(), findUnique: jest.fn() } } },
+      ],
     }).compile();
 
     service = module.get<UserService>(UserService);


### PR DESCRIPTION
## Summary
- add Kafka integration and profiles lookup queue with REST endpoint
- consume lookup requests and push progress via Kafka events
- add missing test mocks for existing services/controllers

## Testing
- `npm run check:build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada66a12fc8331a2c2fc83b53d5698